### PR TITLE
Use US locale to parse NNTP date header

### DIFF
--- a/src/plugins/Freetalk/ui/NNTP/ArticleParser.java
+++ b/src/plugins/Freetalk/ui/NNTP/ArticleParser.java
@@ -561,7 +561,7 @@ public class ArticleParser {
 				dateHeader = dateHeader.substring(dateHeader.indexOf(",") + 2);
 
 			try {
-				date = new SimpleDateFormat("d MMM yyyy HH:mm:ss Z").parse(dateHeader);
+				date = new SimpleDateFormat("d MMM yyyy HH:mm:ss Z", java.util.Locale.US).parse(dateHeader);
 			}
 			catch (ParseException e) {
 				Logger.warning(this, "Failed while parsing date: " + dateHeader, e);


### PR DESCRIPTION
This fixes parsing of the date for users with a locale that doesn't use
the same month abbreviations as the US locale

Fixes bug #5034
