### PR TITLE
Replace \n with <br/> in posts when generating thread page

### DIFF
--- a/src/plugins/Freetalk/ui/web/ThreadPage.java
+++ b/src/plugins/Freetalk/ui/web/ThreadPage.java
@@ -505,7 +505,7 @@ public final class ThreadPage extends WebPageImpl {
 	}
 
 	private static void addTextToNode(HTMLNode parent, String text) {
-		String[] lines = text.split("\n", -1);
+		String[] lines = text.split("\r?\n", -1);
 
 		parent.addChild("#", lines[0]);
 		for(int i = 1; i < lines.length; i++) {


### PR DESCRIPTION
This replaces all newlines in the post with the HTML br element so
copying a post works as expected, instead of the result being one long
line.
